### PR TITLE
Fix assertEquals arguments order

### DIFF
--- a/complete/src/test/kotlin/example/micronaut/HelloControllerSpec.kt
+++ b/complete/src/test/kotlin/example/micronaut/HelloControllerSpec.kt
@@ -15,7 +15,7 @@ object HelloControllerSpec: Spek({
 
         it("test /hello responds Hello World") {
             var rsp : String = client.toBlocking().retrieve("/hello")
-            assertEquals(rsp, "Hello World")
+            assertEquals("Hello World", rsp)
         }
 
         afterGroup {


### PR DESCRIPTION
Just a minor fix.

The arguments order of `org.junit.jupiter.api.Assertions.assertEquals` call should be `expected` first and `actual` second.